### PR TITLE
Start writing text and switch from tui to ratatui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-tui = "0.19.0"
-crossterm = "0.25"
+ratatui = "*"
+tui-input = "*"
+crossterm = "0.26"
 crossbeam-channel = "0.4.2"
 structopt = "0.3"


### PR DESCRIPTION
This PullRequests contains 2 changes:
- Switch from tui to ratatui for UI as the ratatui is community-based successor of tui
- Use tui-input library to write messages and make the first writing block with cursor